### PR TITLE
Get rid of spring-boot-starter-jdbc and explicitly set up autoproxying

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -56,7 +56,6 @@ dependencies {
     compile('org.springframework.boot:spring-boot-starter-web')
     compile('org.springframework.boot:spring-boot-starter-actuator')
     compile('org.springframework.boot:spring-boot-starter-security')
-    compile('org.springframework.boot:spring-boot-starter-jdbc')
     compile('org.springframework.security.oauth:spring-security-oauth2')
     compile('org.springframework.security:spring-security-jwt')
     compile("io.grpc:grpc-protobuf:${grpcVersion}")

--- a/src/main/java/com/revinate/grpcspringsecurity/SecurityConfiguration.java
+++ b/src/main/java/com/revinate/grpcspringsecurity/SecurityConfiguration.java
@@ -30,7 +30,7 @@ import java.util.stream.Collectors;
 @Configuration
 @Order(ManagementServerProperties.ACCESS_OVERRIDE_ORDER)
 @EnableResourceServer
-@EnableGlobalMethodSecurity(prePostEnabled = true)
+@EnableGlobalMethodSecurity(prePostEnabled = true, proxyTargetClass = true)
 public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
 
     private SecurityProperties securityProperties;


### PR DESCRIPTION
As per discussion at https://github.com/LogNet/grpc-spring-boot-starter/issues/61